### PR TITLE
files not saving to BASE_AUTO_GPT fix

### DIFF
--- a/scripts/commands.py
+++ b/scripts/commands.py
@@ -18,7 +18,9 @@ import os
 from dotenv import load_dotenv
 
 cfg = Config()
-
+base_auto_gpt = os.environ.get('BASE_AUTO_GPT')
+allow_outside = False
+if base_auto_gpt: allow_outside = True
 
 def get_command(response):
     try:
@@ -83,11 +85,11 @@ def execute_command(command_name, arguments):
         elif command_name == "get_hyperlinks":
             return get_hyperlinks(arguments["url"])
         elif command_name == "read_file":
-            return read_file(arguments["file"], allow_outside=True)
+            return read_file(arguments["file"], allow_outside=allow_outside)
         elif command_name == "write_to_file":
-            return write_to_file(arguments["file"], arguments["text"])
+            return write_to_file(arguments["file"], arguments["text"], allow_outside=allow_outside)
         elif command_name == "append_to_file":
-            return append_to_file(arguments["file"], arguments["text"])
+            return append_to_file(arguments["file"], arguments["text"], allow_outside=allow_outside)
         elif command_name == "delete_file":
             return delete_file(arguments["file"])
         elif command_name == "browse_website":

--- a/scripts/file_operations.py
+++ b/scripts/file_operations.py
@@ -41,7 +41,7 @@ def read_file(filename, allow_outside=False):
 def read_file_lines(filename, start_line, end_line, allow_outside=False):
     try:
         if allow_outside:
-            filepath = os.path.join("/home/dev/Auto-GPT/", filename)
+            filepath = os.path.join(base_auto_gpt, filename)
         else:
             filepath = safe_join(working_directory, filename)
 
@@ -54,7 +54,7 @@ def read_file_lines(filename, start_line, end_line, allow_outside=False):
 def write_to_file(filename, text, allow_outside=False):
     try:
         if allow_outside:
-            filepath = os.path.join("/home/dev/Auto-GPT/", filename)
+            filepath = os.path.join(base_auto_gpt, filename)
         else:
             filepath = safe_join(working_directory, filename)
 
@@ -70,7 +70,7 @@ def write_to_file(filename, text, allow_outside=False):
 def append_to_file(filename, text, allow_outside=False):
     try:
         if allow_outside:
-            filepath = os.path.join("/home/dev/Auto-GPT/", filename)
+            filepath = os.path.join(base_auto_gpt, filename)
         else:
             filepath = safe_join(working_directory, filename)
 


### PR DESCRIPTION
I was having trouble finding the files that AutoGPTCommands was saving. I had understood BASE_AUTO_GPT to be the directory where it was saving and still couldn't find it.

So I took a look in the code and found some issues.

my .env file

```
OPENAI_API_KEY=my-key-here
#ELEVENLABS_API_KEY=your-elevenlabs-api-key
FAST_LLM_MODEL="gpt-3.5-turbo"
SMART_LLM_MODEL="gpt-3.5-turbo"
#GOOGLE_API_KEY=your-search-api-key
#CUSTOM_SEARCH_ENGINE_ID=your-custom-search-engine-id
SEARX_URL=http://my-searchx-server-here.com
SEARX_USERNAME=''
SEARX_PASSWORD=''
BASE_AUTO_GPT=/root/AutoGPTCommands/auto_gpt_workspace
```

So the entire time I was looking for it inside of `/root/AutoGPTCommands/auto_gpt_workspace` but it wasn't there.

I did _eventually_ find that it was saving inside of the scripts folder. Seemed weird because then what was the point of my BASE_AUTO_GPT variable.

Inside of the file `scripts/file_operations.py`, I noticed that the functions:
`read_file_lines(filename, start_line, end_line, text, allow_outside=False)`
`write_to_file(filename, text, allow_outside=False)`
`append_to_file(filename, text, allow_outside=False)`

all had these lines inside:
```python
# scripts/file_operations.py
if allow_outside:
    filepath = os.path.join("/home/dev/Auto-GPT/", filename)
else:
    filepath = safe_join(working_directory, filename)
```

That filepath here is hardcoded when it shouldn't be. I noticed that in the function: 
`read_file(filename, allow_outside=False)`
 it had our variable of `base_auto_gpt` that held our environment variable `BASE_AUTO_GPT`

So I changed the other functions to follow suit.

When I ran the AI again, I noticed that it still didn't save anything to my BASE_AUTO_GPT directory unless I changed `allowed_outside` to `True`. However, just to avoid any issues by doing that I looked at the functions that were calling the above functions and added these lines to the top of `scripts/commands.py`:

```python3
# scripts/commands.py
# import functions here
# ....

cfg = Config() # was already here didn't add this.

# added these
base_auto_gpt = os.environ.get('BASE_AUTO_GPT')
allow_outside = False
if base_auto_gpt: allow_outside = True

# all other code below ...
# ...

# I then added the allow_outside variable below like so inside the existing `execute_command`
def execute_command(command_name, arguments):
# ....
# ...
    elif command_name == "read_file":
        return read_file(arguments["file"], allow_outside=allow_outside
    elif command_name == "write_to_file":
        return read_file(arguments["file"], arguments["text"], allow_outside=allow_outside
    elif command_name == "append_to_file":
        return read_file(arguments["file"], arguments["text"] allow_outside=allow_outside
# ...
```

This then solved my issue and started saving all my output logs by AutoGPTCommands inside the directory I wanted to use in the BASE_AUTO_GPT variable for .env

BASE_AUTO_GPT doesn't have to be set now. The code will still work and just default to placing the output files inside of `scripts/auto_gpt_workspace` as its default location if BASE_AUTO_GPT is missing.

Hope this helps.